### PR TITLE
Control if redis uses async-std or tokio via feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,13 @@ license = "BSD-3-Clause"
 readme = "README.md"
 edition = "2021"
 
+[features]
+async-std-comp = ["redis/async-std-comp"]
+tokio-comp = ["redis/tokio-comp"]
+default = ["async-std-comp"]
+
 [dependencies]
-redis = { version = "0.21.6", features = ["async-std-comp"] }
+redis = { version = "0.21.6" }
 tokio = { version = "1.27.0", features = ["rt", "time"] }
 rand = "0.8.5"
 futures = "0.3.24"


### PR DESCRIPTION
Unsure why async-std-comp was used, if tokio is taken as a direct dependency. 